### PR TITLE
Temporary workaround for rendering selected year issue

### DIFF
--- a/etools-datepicker.html
+++ b/etools-datepicker.html
@@ -156,6 +156,15 @@ Custom property | Description | Default
               this._updateDate();
             }
           }.bind(this), 0);
+          this._selectedYearFix();
+        },
+        _selectedYearFix: function() {
+          var datepicker = Polymer.dom(this.root).querySelector('#picker'),
+              yearList = datepicker && datepicker.$ && datepicker.$.yearList;
+
+          if (yearList) {
+            yearList.listen(yearList,  'iron-resize', 'centerSelected');
+          }
         },
         _updateDate: function() {
           if (!this.date) {

--- a/etools-datepicker.html
+++ b/etools-datepicker.html
@@ -156,6 +156,7 @@ Custom property | Description | Default
               this._updateDate();
             }
           }.bind(this), 0);
+          //TODO: remove this method after closing issue in paper-date-picker (https://github.com/bendavis78/paper-date-picker/issues/187) -->
           this._selectedYearFix();
         },
         _selectedYearFix: function() {
@@ -165,6 +166,7 @@ Custom property | Description | Default
           if (yearList) {
             yearList.listen(yearList,  'iron-resize', 'centerSelected');
           }
+          // <-- end remove -->
         },
         _updateDate: function() {
           if (!this.date) {


### PR DESCRIPTION
Hey, 

This is the temporary workaround for this issue:
https://github.com/unicef-polymer/etools-datepicker/issues/5


We can have it in the code until [this issue](https://github.com/bendavis78/paper-date-picker/issues/187) is fixed in [paper-date-picker](https://github.com/bendavis78/paper-date-picker)